### PR TITLE
Merge SocketAsyncEventArgs into SocketAwaitable and use cached instances

### DIFF
--- a/src/AdsClient/AmsSocketConnection.cs
+++ b/src/AdsClient/AmsSocketConnection.cs
@@ -6,22 +6,23 @@ using Viscon.Communication.Ads.Internal;
 
 namespace Viscon.Communication.Ads;
 
-internal class AmsSocketConnection
+internal sealed class AmsSocketConnection
 {
     private const int ReceiveTaskTimeout = 3000;
 
     private readonly Socket socket;
     private readonly IIncomingMessageHandler messageHandler;
     private readonly Task receiveTask;
+    private readonly SocketAwaitable socketAwaitable = new SocketAwaitable();
 
     public AmsSocketConnection(Socket socket, IIncomingMessageHandler messageHandler)
     {
         this.socket = socket;
         this.messageHandler = messageHandler;
-        receiveTask = Task.Run(ReceiveLoop);
+        receiveTask = ReceiveLoop();
     }
 
-    private bool closed;
+    private volatile bool closed;
 
     public void Close()
     {
@@ -30,6 +31,7 @@ internal class AmsSocketConnection
         socket.Close();
 
         receiveTask.Wait(ReceiveTaskTimeout);
+        socketAwaitable.Dispose();
     }
 
     private async Task<byte[]> GetAmsMessage(byte[] tcpHeader)
@@ -49,7 +51,6 @@ internal class AmsSocketConnection
 
     private async Task Listen()
     {
-
         try
         {
             var buffer = await ListenForHeader();
@@ -86,25 +87,26 @@ internal class AmsSocketConnection
 
     private async Task ReceiveAsync(byte[] buffer)
     {
-        using var args = new SocketAsyncEventArgs();
-        args.SetBuffer(buffer, 0, buffer.Length);
-        var awaitable = new SocketAwaitable(args);
+        var sa = socketAwaitable;
+        sa.SetBuffer(buffer, 0, buffer.Length);
 
         do
         {
-            args.SetBuffer(args.Offset + args.BytesTransferred, args.Count - args.BytesTransferred);
-            await socket.ReceiveAsync(awaitable);
+            sa.SetBuffer(sa.Offset + sa.BytesTransferred, sa.Count - sa.BytesTransferred);
+            await socket.ReceiveAwaitable(sa);
 
-            if (args.BytesTransferred == 0)
+            if (sa.BytesTransferred == 0)
             {
                 messageHandler.HandleException(new Exception("Remote host closed the connection."));
                 Close();
             }
-        } while (args.Count != args.BytesTransferred);
+        } while (socketAwaitable.BytesTransferred != buffer.Length);
     }
 
     private async Task ReceiveLoop()
     {
+        await Task.Yield();
+
         while (!closed)
         {
             await Listen();

--- a/src/AdsClient/AmsSocketConnection.cs
+++ b/src/AdsClient/AmsSocketConnection.cs
@@ -14,6 +14,7 @@ internal sealed class AmsSocketConnection
     private readonly IIncomingMessageHandler messageHandler;
     private readonly Task receiveTask;
     private readonly SocketAwaitable socketAwaitable = new SocketAwaitable();
+    private readonly byte[] headerBuffer = new byte[AmsHeaderHelper.AmsTcpHeaderSize];
 
     public AmsSocketConnection(Socket socket, IIncomingMessageHandler messageHandler)
     {
@@ -79,10 +80,8 @@ internal sealed class AmsSocketConnection
 
     private async Task<byte[]> ListenForHeader()
     {
-        var buffer = new byte[AmsHeaderHelper.AmsTcpHeaderSize];
-        await ReceiveAsync(buffer);
-
-        return buffer;
+        await ReceiveAsync(headerBuffer);
+        return headerBuffer;
     }
 
     private async Task ReceiveAsync(byte[] buffer)

--- a/src/AdsClient/Helpers/IdGenerator.cs
+++ b/src/AdsClient/Helpers/IdGenerator.cs
@@ -1,15 +1,14 @@
-﻿using System.Runtime.CompilerServices;
-using System.Threading;
+﻿using System.Threading;
 
 namespace Viscon.Communication.Ads.Helpers
 {
     internal class IdGenerator
     {
-        private uint id;
+        private int id;
 
         public uint Next()
         {
-            return (uint)Interlocked.Increment(ref Unsafe.As<uint, int>(ref id));
+            return (uint)Interlocked.Increment(ref id);
         }
     }
 }

--- a/src/AdsClient/Internal/Assertions.cs
+++ b/src/AdsClient/Internal/Assertions.cs
@@ -6,7 +6,7 @@ internal class Assertions
 {
     public static void AssertDataLength(ReadOnlySpan<byte> buffer, int length, int offset)
     {
-        if (length + offset != buffer.Length)
+        if (length != buffer.Length - offset)
         {
             throw new Exception(
                 $"Received {buffer.Length} bytes of data, but length indicates {length} bytes remaining at offset {offset}, resulting in a expected total of {length + offset} bytes.");

--- a/src/AdsClient/Internal/SocketExtensions.cs
+++ b/src/AdsClient/Internal/SocketExtensions.cs
@@ -10,18 +10,18 @@ namespace Viscon.Communication.Ads.Internal;
 /// </remarks>
 internal static class SocketExtensions
 {
-    public static SocketAwaitable ReceiveAsync(this Socket socket, SocketAwaitable awaitable)
+    public static SocketAwaitable ReceiveAwaitable(this Socket socket, SocketAwaitable awaitable)
     {
         awaitable.Reset();
-        if (!socket.ReceiveAsync(awaitable.EventArgs))
+        if (!socket.ReceiveAsync(awaitable))
             awaitable.WasCompleted = true;
         return awaitable;
     }
 
-    public static SocketAwaitable SendAsync(this Socket socket, SocketAwaitable awaitable)
+    public static SocketAwaitable SendAwaitable(this Socket socket, SocketAwaitable awaitable)
     {
         awaitable.Reset();
-        if (!socket.SendAsync(awaitable.EventArgs))
+        if (!socket.SendAsync(awaitable))
             awaitable.WasCompleted = true;
         return awaitable;
     }

--- a/src/AdsClient/Internal/TypeExtensions.cs
+++ b/src/AdsClient/Internal/TypeExtensions.cs
@@ -28,6 +28,8 @@ internal static class TypeExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref byte GetOffset(this ref byte source, int offset)
     {
-        return ref Unsafe.Add(ref source, offset);
+        // The cast to uint is in order to avoid a sign-extending move
+        // in the machine code.
+        return ref Unsafe.Add(ref source, (uint)offset);
     }
 }


### PR DESCRIPTION
For socket operation:
Instead of creating (allocating) a SocketAsyncEventArgs and then a SocketAwaitable both are "merged" into one instance, which can be cached and re-used. Thus avoiding allocations and make it amortized allocation-free.

This could be driven further, by using ValueTask instead of Task. But with the current targets (< .NET 6) it's a bit cumbersome, so I didn't do this now.

---

@mycroes you mentioned this project in Sally7, so I had a quick look 😉.